### PR TITLE
商品削除機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :destroy]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def set_item
     @item = Item.find(params[:id])
@@ -28,7 +28,7 @@ class ItemsController < ApplicationController
 
   def edit
     unless @item.user.id == current_user.id
-      redirect_to action: :index
+      redirect_to root_path
     end
   end
 
@@ -38,6 +38,13 @@ class ItemsController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    if @item.user.id == current_user.id
+      @item.destroy
+    end
+    redirect_to root_path
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
       <% if current_user.id == @item.user.id %>
         <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", item_path, data: { turbo_method: :delete }, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item.id), data: { turbo_method: :delete }, class:"item-destroy" %>
       <% else %>
         <%# 商品が売れていない場合はこちらを表示しましょう %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
       <% if current_user.id == @item.user.id %>
         <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path, data: { turbo_method: :delete }, class:"item-destroy" %>
       <% else %>
         <%# 商品が売れていない場合はこちらを表示しましょう %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
   root 'items#index'
 end


### PR DESCRIPTION
#What
商品削除機能の実装

#Why
furimaの機能要件である「商品削除機能」を実現するため

#GyazoのURL
ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/65048e18187af728063626fff9e11709

レビューよろしくお願いいたします！